### PR TITLE
Avoid unnecessary grokking of package.

### DIFF
--- a/collective/geo/zugmap/configure.zcml
+++ b/collective/geo/zugmap/configure.zcml
@@ -9,9 +9,6 @@
     <!-- Include configuration for dependencies listed in setup.py -->
     <includeDependencies package="." />
 
-    <!-- Grok the package to initialise schema interfaces and content classes -->
-    <grok:grok package="." />
-
     <!-- Register an extension profile to make the product installable -->
     <genericsetup:registerProfile
         name="default"

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,5 +5,8 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Removed unnecessary grokking of package.
+  [lgraf]
+
 - Initial release.
   [href]


### PR DESCRIPTION
In `configure.zcml` the package was grokked, but `setup.py` doesn't declare a dependency on `five.grok`. After a quick check I couldn't find any code that actually uses grok, so I removed it.

(Also fixed the changelog format so it will display nicely on PyPi and can be dealt with by `zest.releaser`).
