### PR TITLE
Load maps from "maps.zg.ch" instead of "maps.zug.ch".

### DIFF
--- a/collective/geo/zugmap/browser/layers_templates/zugmap_orthofotoplus_layer.pt
+++ b/collective/geo/zugmap/browser/layers_templates/zugmap_orthofotoplus_layer.pt
@@ -30,7 +30,7 @@ function() {
     var layer = new OpenLayers.Layer.WMTS({
         name : "LuftbildPlus+ (GIS Kanton Zug)",
         url : [
-            "https://maps.zug.ch/luftbildplus_tiled/service.svc/get"
+            "https://maps.zg.ch/luftbildplus_tiled/service.svc/get"
         ],
         layer : "LuftbildPlusGoogle",
         matrixSet : "LuftbildPlusGoogle",

--- a/collective/geo/zugmap/browser/layers_templates/zugmap_ortsplan_layer.pt
+++ b/collective/geo/zugmap/browser/layers_templates/zugmap_ortsplan_layer.pt
@@ -29,7 +29,7 @@ function() {
     return new OpenLayers.Layer.WMTS({
         name : "Ortsplan (GIS Kanton Zug)",
         url : [
-            "https://maps.zug.ch/ortsplan_tiled/service.svc/get"
+            "https://maps.zg.ch/ortsplan_tiled/service.svc/get"
         ],
         layer : "Ortsplan",
         matrixSet : "Ortsplan",

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.0.5 (unreleased)
+------------------
+
+- Load maps from "maps.zg.ch" instead of "maps.zug.ch".
+  [mbaechtold]
+
 1.0.4
 -----
 


### PR DESCRIPTION
The domain the map images are served from has been changed by the operators of the maps application oh the canton of Zug causing pages like https://www.zg.ch/behoerden/baudirektion/addresse/addressblock_detail_view to no longer render the maps.

This has been reported by @brhi via the private tracking tool of 4teamwork.